### PR TITLE
Updated get secrets script to allow for an array of keyvault names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.35]
+
+- Updated get secrets script to allow for an array of keyvault names to be specified.
+
 ## [1.0.34]
 
 - Added: generateReport method in AxeUtils to create a consolidated HTML accessibility report across multiple pages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added table & wait utilities
 
-[1.0.34]: https://github.com/hmcts/playwright-common/compare/v1.0.34...HEAD
+[1.0.35]: https://github.com/hmcts/playwright-common/compare/v1.0.35...HEAD
+[1.0.34]: https://github.com/hmcts/playwright-common/compare/v1.0.34...v1.0.35
 [1.0.33]: https://github.com/hmcts/playwright-common/compare/v1.0.33...v1.0.34
 [1.0.32]: https://github.com/hmcts/playwright-common/compare/v1.0.32...v1.0.33
 [1.0.31]: https://github.com/hmcts/playwright-common/compare/v1.0.31...v1.0.32

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/playwright-common",
   "description": "Common library for Playwright tests",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "author": "HMCTS",
   "license": "MIT",
   "repository": {

--- a/src/scripts/get-secrets.js
+++ b/src/scripts/get-secrets.js
@@ -65,19 +65,29 @@ function updateEnvFile(secretsMap, exampleEnvFilePath, envFilePath) {
 /**
  * Populates the .env file with secrets from Azure key vault. Maintains the structure of the .env.example file.
  *
- * @param keyVaultName {@link string} - The name of the Azure Key Vault to fetch secrets from
+ * @param {string|string[]} keyVaultNames - One or more Azure Key Vault names to fetch secrets from
  * @param exampleEnvFilePath {@link string} - Path to the example .env file (optional, default is .env.example)
  * @param envFilePath {@link string} - Path to the .env file (optional, default is .env)
- *
  */
 export function populateSecrets(
-  keyVaultName,
+  keyVaultNames,
   exampleEnvFilePath = DEFAULT_EXAMPLE_ENV_FILE,
   envFilePath = DEFAULT_ENV_FILE
 ) {
   try {
-    const secrets = getTaggedSecrets(keyVaultName);
-    updateEnvFile(secrets, exampleEnvFilePath, envFilePath);
+    const vaults = Array.isArray(keyVaultNames)
+      ? keyVaultNames
+      : [keyVaultNames];
+
+    const allSecrets = {};
+    for (const vault of vaults) {
+      const secrets = getTaggedSecrets(vault);
+      for (const [key, value] of Object.entries(secrets)) {
+        allSecrets[key] = value;
+      }
+    }
+
+    updateEnvFile(allSecrets, exampleEnvFilePath, envFilePath);
   } catch (err) {
     console.error("Error:", err.message);
     process.exit(1);


### PR DESCRIPTION
### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

- Updated get secrets script to allow for an array of keyvault names to be specified

### Testing done

- Tested script locally to ensure a single keyvault name or an array of keyvault names can be used to fetch secrets

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
