### PR TITLE
Redact sensitive session attributes from string values in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,9 +223,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added table & wait utilities
 
-[1.1.4]: https://github.com/hmcts/playwright-common/compare/v1.1.3...HEAD
-[1.1.3]: https://github.com/hmcts/playwright-common/compare/v1.1.2...HEAD
-[1.1.2]: https://github.com/hmcts/playwright-common/compare/v1.1.1...v1.1.3
+[1.1.4]: https://github.com/hmcts/playwright-common/compare/v1.1.4...HEAD
+[1.1.3]: https://github.com/hmcts/playwright-common/compare/v1.1.3...v1.1.4
+[1.1.2]: https://github.com/hmcts/playwright-common/compare/v1.1.2...v1.1.3
 [1.1.1]: https://github.com/hmcts/playwright-common/compare/v1.1.1...v1.1.2
 [1.1.0]: https://github.com/hmcts/playwright-common/compare/v1.1.0...v1.1.1
 [1.0.39]: https://github.com/hmcts/playwright-common/compare/v1.0.39...v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.4]
+### Update
+- update logging to include redaction of session attributes when sanitising string values
+
 ## [1.1.3]
 ### Update
 - update playwright version to 1.61.0 (to resolve issues with bug with installing browsers)
@@ -82,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.39]
 
 - Updated the table scraping function to allow for checkboxes that might occur on the right hand side of the table.
-  
+
 ## [1.0.38]
 
 - Updated S2S_SECRET is now optional.
@@ -219,6 +223,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added table & wait utilities
 
+[1.1.4]: https://github.com/hmcts/playwright-common/compare/v1.1.3...HEAD
 [1.1.3]: https://github.com/hmcts/playwright-common/compare/v1.1.2...HEAD
 [1.1.2]: https://github.com/hmcts/playwright-common/compare/v1.1.1...v1.1.3
 [1.1.1]: https://github.com/hmcts/playwright-common/compare/v1.1.1...v1.1.2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/playwright-common",
   "description": "Common library for Playwright tests",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "author": "HMCTS",
   "license": "MIT",
   "repository": {

--- a/src/logging/redaction.ts
+++ b/src/logging/redaction.ts
@@ -1,4 +1,4 @@
-import { URL } from "node:url";
+import {URL} from "node:url";
 
 export const REDACTED_VALUE = "[REDACTED]";
 const CIRCULAR_PLACEHOLDER = "[Circular]";
@@ -8,7 +8,7 @@ export type RedactPattern = string | RegExp;
 
 const TOKEN_TEXT_REGEX = /(Bearer\s+)([A-Z0-9.-]+)/gi;
 const KEY_VALUE_SECRET_REGEX =
-  /((?:token|secret|password|api[_-]?key)[^:=]*)([:=]\s*)(["']?)([^"'\s]+)/gi;
+  /((?:token|secret|password|session|api[_-]?key)[^:=]*)([:=]\s*)(["']?)([^"'\s]+)/gi;
 
 const DEFAULT_PATTERNS: RegExp[] = [
   /token/i,
@@ -45,10 +45,10 @@ export function buildRedactionState(
   const enabled = options?.enabled ?? true;
   const patterns = options?.patterns?.length
     ? options.patterns.map((pattern) =>
-        typeof pattern === "string" ? new RegExp(pattern, "i") : pattern
-      )
+      typeof pattern === "string" ? new RegExp(pattern, "i") : pattern
+    )
     : DEFAULT_PATTERNS;
-  return { enabled, patterns };
+  return {enabled, patterns};
 }
 
 export function shouldRedactKey(
@@ -61,11 +61,11 @@ export function shouldRedactKey(
 
 /**
  * Recursively sanitize a value by redacting sensitive fields and string patterns.
- * 
+ *
  * Note: The returned value maintains the same structure as the input, but with
  * sensitive data replaced with [REDACTED]. The type cast to T is safe because
  * the structure is preserved, only values are changed.
- * 
+ *
  * @param value - Value to sanitize
  * @param state - Redaction state with enabled flag and patterns
  * @param key - Optional key name for determining if the value itself should be redacted

--- a/src/logging/redaction.ts
+++ b/src/logging/redaction.ts
@@ -1,4 +1,4 @@
-import {URL} from "node:url";
+import { URL } from "node:url";
 
 export const REDACTED_VALUE = "[REDACTED]";
 const CIRCULAR_PLACEHOLDER = "[Circular]";
@@ -48,7 +48,7 @@ export function buildRedactionState(
       typeof pattern === "string" ? new RegExp(pattern, "i") : pattern
     )
     : DEFAULT_PATTERNS;
-  return {enabled, patterns};
+  return { enabled, patterns };
 }
 
 export function shouldRedactKey(

--- a/tests/logging/redaction.spec.ts
+++ b/tests/logging/redaction.spec.ts
@@ -55,7 +55,7 @@ describe("redaction utilities", () => {
     const result = sanitiseValue(payload, state);
 
     expect(result.password).toBe(REDACTED_VALUE);
-    expect(result.nested).toEqual({token: REDACTED_VALUE});
+    expect(result.nested).toEqual({ token: REDACTED_VALUE });
     expect(result.self).toBe("[Circular]");
   });
 

--- a/tests/logging/redaction.spec.ts
+++ b/tests/logging/redaction.spec.ts
@@ -55,7 +55,7 @@ describe("redaction utilities", () => {
     const result = sanitiseValue(payload, state);
 
     expect(result.password).toBe(REDACTED_VALUE);
-    expect(result.nested).toEqual({ token: REDACTED_VALUE });
+    expect(result.nested).toEqual({token: REDACTED_VALUE});
     expect(result.self).toBe("[Circular]");
   });
 
@@ -85,4 +85,14 @@ describe("redaction utilities", () => {
     expect(result[1]).toEqual({ nested: [{ password: REDACTED_VALUE }] });
     expect(result[2]).toContain(REDACTED_VALUE);
   });
+
+  it("redacts sensitive values within strings", () => {
+    const payload = {
+      error: "cookie: secret=abc XSRF-TOKEN=123 session=abc123 harmless=value",
+    };
+
+    const result = sanitiseValue(payload, state);
+
+    expect(result.error).toBe("cookie: secret=[REDACTED] XSRF-TOKEN=[REDACTED] session=[REDACTED] harmless=value");
+  })
 });


### PR DESCRIPTION
### Jira link

See [FPVTL-3401](https://tools.hmcts.net/jira/browse/FPVTL-3401)

### Change description

- We found error logs from idam utils were logging the session string which contains the bearer token so I have redacted sensitive session values from strings in logs

### Testing done

- Added a new test in redaction.spec.ts and all unit tests are passing in the file:
<img width="701" height="316" alt="Screenshot 2026-08-05 at 11 52 07" src="https://github.com/user-attachments/assets/620ac008-1bb1-4925-ba8e-dbd9b8536f95" />

Test passing using local playwright common package containing the change:
<img width="1436" height="884" alt="Screenshot 2026-08-06 at 12 39 13" src="https://github.com/user-attachments/assets/3561827c-da4c-472d-9c2b-51151c8a7223" />


### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
